### PR TITLE
Added cross-env for Windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@storybook/addon-ondevice-controls": "^6.5.1",
     "@storybook/react-native": "^6.5.1",
     "babel-loader": "^8.3.0",
+    "cross-env": "^7.0.3",
     "react-native-safe-area-context": "^4.5.0"
   },
   "scripts": {
@@ -28,9 +29,9 @@
     "web": "expo start --web",
     "storybook-generate": "sb-rn-get-stories",
     "storybook-watch": "sb-rn-watcher",
-    "storybook": "sb-rn-get-stories && STORYBOOK_ENABLED='true' expo start",
-    "storybook:ios": "sb-rn-get-stories && STORYBOOK_ENABLED='true' expo start --ios",
-    "storybook:android": "sb-rn-get-stories && STORYBOOK_ENABLED='true' expo start --android"
+    "storybook": "sb-rn-get-stories && cross-env STORYBOOK_ENABLED='true' expo start",
+    "storybook:ios": "sb-rn-get-stories && cross-env STORYBOOK_ENABLED='true' expo start --ios",
+    "storybook:android": "sb-rn-get-stories && cross-env STORYBOOK_ENABLED='true' expo start --android"
   },
   "version": "1.0.0",
   "private": true,


### PR DESCRIPTION
Added cross-env for Windows compatibility

Fixes [issue #460](https://github.com/storybookjs/react-native/issues/460)